### PR TITLE
update default.nix to 8.8.4

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ compiler ? "ghc8104"
+{ compiler ? "ghc884"
 , system ? builtins.currentSystem
 , pkgs ? import ./dep/nixpkgs { inherit system; }
 }:


### PR DESCRIPTION
@myShoggoth @Ericson2314 

ghc8104 actually has failing packages, which require a little more work to smooth out. I'll have a branch up for 8.10 support quickly. In the meantime, bumping to 8.8.4 works, and is cached nicely.

