### PR TITLE
Add link to Tweag as Richard's employer

### DIFF
--- a/site/who-we-are/index.html
+++ b/site/who-we-are/index.html
@@ -109,7 +109,7 @@ Emily has since developed a proclivity for OSS and community contributions, auth
           </div>
         </div>
         <p>
-          Richard has a long track record of contributing to Haskell (GHC, in particular) for the past 8 years, including many publications pushing the boundaries of what Haskell can accomplish. He implemented <tt>-XTypeInType</tt> and <tt>-XTypeApplications</tt>, has done considerable work on the constraint solver, type checker, and core language representations in GHC. He is also the author of singletons, serves on the GHC Steering Committee, and was an early member of the HF working group, driving the development of its initial technical agendas. He has been chair of the Haskell Symposium and Haskell Implementors' Workshop and is driving the efforts on Dependent Haskell. Richard currently works at Tweag as a Principal Researcher.
+          Richard has a long track record of contributing to Haskell (GHC, in particular) for the past 8 years, including many publications pushing the boundaries of what Haskell can accomplish. He implemented <tt>-XTypeInType</tt> and <tt>-XTypeApplications</tt>, has done considerable work on the constraint solver, type checker, and core language representations in GHC. He is also the author of singletons, serves on the GHC Steering Committee, and was an early member of the HF working group, driving the development of its initial technical agendas. He has been chair of the Haskell Symposium and Haskell Implementors' Workshop and is driving the efforts on Dependent Haskell. Richard currently works at <a href="https://tweag.io/">Tweag</a> as a Principal Researcher.
         </p>
         <div>
           <div class="font-bold text-gray-600">Committees</div>


### PR DESCRIPTION
Should we link to board members' employers? I think so, as helpful to our readers and also as a small "thank you" to the employers for allowing board members to serve.